### PR TITLE
Add more descriptive protected page error

### DIFF
--- a/Extension-React/src/App.tsx
+++ b/Extension-React/src/App.tsx
@@ -8,7 +8,7 @@ const domainReplacements: any = {
     "nordcheckout.com": "nordvpn.com",
 };
 
-const protectedDomains: string[] = [
+const reservedDomains: string[] = [
     'chrome://',
     'chrome-extension://',
     'edge://',
@@ -36,8 +36,8 @@ const Popup: React.FC = () => {
                 fullDomain = searchParams.get("domain") || "";
             }
 
-            if (protectedDomains.some(domain => fullDomain.includes(domain))) {
-                setErrorMsg("This page is protected by the browser.");
+            if (reservedDomains.some(domain => fullDomain.includes(domain))) {
+                setErrorMsg("Syrup looks for coupons online when you shop!");
                 return;
             }
 
@@ -81,8 +81,8 @@ const Popup: React.FC = () => {
                     const url = new URL(tab.url);
                     const fullDomain = url.hostname.replace("www.", "");
 
-                    if (protectedDomains.some(domain => url.origin.includes(domain))) {
-                        setErrorMsg("This page is protected by the browser.");
+                    if (reservedDomains.some(domain => url.origin.includes(domain))) {
+                        setErrorMsg("Syrup looks for coupons online when you shop!");
                         return;
                     }
 

--- a/Extension-React/src/App.tsx
+++ b/Extension-React/src/App.tsx
@@ -8,6 +8,15 @@ const domainReplacements: any = {
     "nordcheckout.com": "nordvpn.com",
 };
 
+const protectedDomains: string[] = [
+    'chrome://',
+    'chrome-extension://',
+    'edge://',
+    'about:',
+    'mozilla:',
+    'newtab',
+];
+
 const Popup: React.FC = () => {
     const [pageDomain, setPageDomain] = useState<string>("");
     const [pageSubDomain, setPageSubDomain] = useState<string>("");
@@ -25,6 +34,11 @@ const Popup: React.FC = () => {
             const searchParams = new URLSearchParams(window.location.search);
             if (searchParams.has("domain")) {
                 fullDomain = searchParams.get("domain") || "";
+            }
+
+            if (protectedDomains.some(domain => fullDomain.includes(domain))) {
+                setErrorMsg("This page is protected by the browser.");
+                return;
             }
 
             const parseResult: any = parseDomain(
@@ -66,6 +80,11 @@ const Popup: React.FC = () => {
                 if (tab.url) {
                     const url = new URL(tab.url);
                     const fullDomain = url.hostname.replace("www.", "");
+
+                    if (protectedDomains.some(domain => url.origin.includes(domain))) {
+                        setErrorMsg("This page is protected by the browser.");
+                        return;
+                    }
 
                     const parseResult: any = parseDomain(
                         domainReplacements[fullDomain] || fullDomain


### PR DESCRIPTION
While using I noticed that if you opened it on a newtab / chrome page it would give you a generic "domain seems invalid", so I just made it more specific for that case