### PR TITLE
docs: include rate limit in all responses

### DIFF
--- a/backend/standard/swagger.yaml
+++ b/backend/standard/swagger.yaml
@@ -15,10 +15,52 @@ paths:
       responses:
         '200':
           description: Successful response
+          headers:
+            X-RateLimit-Limit:
+              description: The maximum number of requests allowed per time window
+              schema:
+                type: integer
+            X-RateLimit-Remaining:
+              description: The number of requests remaining in the time window
+              schema:
+                type: integer
+            X-RateLimit-Reset:
+              description: The time when the rate limit window resets (Unix timestamp)
+              schema:
+                type: integer
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/VersionInfo'
+                $ref: '#/components/schemas/CouponList'
+        '400':
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '429':
+          description: Too Many Requests
+          headers:
+            X-RateLimit-RetryAfter:
+              description: Time to wait before retrying (seconds)
+              schema:
+                type: integer
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '500':
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
   /coupons:
     get:
       summary: List Coupons
@@ -108,9 +150,49 @@ paths:
             type: string
       responses:
         '200':
-          description: Success
-        '404':
-          description: Coupon not found
+          description: Successful response
+          headers:
+            X-RateLimit-Limit:
+              description: The maximum number of requests allowed per time window
+              schema:
+                type: integer
+            X-RateLimit-Remaining:
+              description: The number of requests remaining in the time window
+              schema:
+                type: integer
+            X-RateLimit-Reset:
+              description: The time when the rate limit window resets (Unix timestamp)
+              schema:
+                type: integer
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CouponList'
+        '400':
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '429':
+          description: Too Many Requests
+          headers:
+            X-RateLimit-RetryAfter:
+              description: Time to wait before retrying (seconds)
+              schema:
+                type: integer
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '500':
+          description: Internal Server Error
           content:
             application/json:
               schema:
@@ -129,9 +211,49 @@ paths:
             type: string
       responses:
         '200':
-          description: Success
-        '404':
-          description: Coupon not found
+          description: Successful response
+          headers:
+            X-RateLimit-Limit:
+              description: The maximum number of requests allowed per time window
+              schema:
+                type: integer
+            X-RateLimit-Remaining:
+              description: The number of requests remaining in the time window
+              schema:
+                type: integer
+            X-RateLimit-Reset:
+              description: The time when the rate limit window resets (Unix timestamp)
+              schema:
+                type: integer
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CouponList'
+        '400':
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '429':
+          description: Too Many Requests
+          headers:
+            X-RateLimit-RetryAfter:
+              description: Time to wait before retrying (seconds)
+              schema:
+                type: integer
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '500':
+          description: Internal Server Error
           content:
             application/json:
               schema:

--- a/backend/standard/swagger.yaml
+++ b/backend/standard/swagger.yaml
@@ -31,7 +31,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/CouponList'
+                $ref: '#/components/schemas/VersionInfo'
         '400':
           description: Bad Request
           content:
@@ -167,7 +167,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/CouponList'
+                $ref: '#/components/schemas/Success'
         '400':
           description: Bad Request
           content:
@@ -228,7 +228,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/CouponList'
+                $ref: '#/components/schemas/Success'
         '400':
           description: Bad Request
           content:
@@ -324,6 +324,14 @@ components:
         message:
           type: string
           description: Detailed error message
+    Success:
+      type: object
+      required:
+          - success
+      properties:
+          success:
+            type: string
+            description: Success message
   securitySchemes:
     ApiKeyAuth:
       type: apiKey


### PR DESCRIPTION
I think the endpoint should always return the rate limit data. Providers can still choose if they return real rate limits or just always return valid ones.