### PR TITLE
[API Docs] Use JSONC code blocks to avoid red background around comments

### DIFF
--- a/backend/standard/README.md
+++ b/backend/standard/README.md
@@ -34,11 +34,11 @@ The Coupon structure represents a single coupon code and its metadata. Each fiel
 
 ```jsonc
 {
-    "id": "string",          // Unique identifier for the coupon
-    "title": "string",       // Display title with discount amount
-    "description": "string", // Detailed coupon information
-    "code": "string",        // The actual coupon code
-    "score": number,         // Relevance/reliability score
+    "id": "string",           // Unique identifier for the coupon
+    "title": "string",        // Display title with discount amount
+    "description": "string",  // Detailed coupon information
+    "code": "string",         // The actual coupon code
+    "score": number,          // Relevance/reliability score
     "merchant_name": "string" // Store/website name
 }
 ```

--- a/backend/standard/README.md
+++ b/backend/standard/README.md
@@ -32,7 +32,7 @@ Key characteristics of the authentication system:
 ### Coupon
 The Coupon structure represents a single coupon code and its metadata. Each field serves a specific purpose:
 
-```json
+```jsonc
 {
     "id": "string",          // Unique identifier for the coupon
     "title": "string",       // Display title with discount amount
@@ -63,7 +63,7 @@ Field Details:
 ### VersionInfo
 The VersionInfo structure helps track API compatibility:
 
-```json
+```jsonc
 {
     "version": "string", // Semantic versioning recommended
     "provider": "string" // Provider's name or identifier
@@ -80,7 +80,7 @@ GET /syrup/version
 ```
 
 #### Response
-```json
+```jsonc
 {
     "version": "1.0.0",
     "provider": "ExampleProvider"
@@ -109,7 +109,7 @@ GET /syrup/coupons
 | X-RateLimit-Reset    | The time when the rate limit window resets (Unix timestamp)|
 
 #### Response Body
-```json
+```jsonc
 {
     "coupons": [
         {
@@ -188,7 +188,7 @@ The API uses standard HTTP status codes with specific meanings in the context of
     - System failures
 
 Error responses should include a descriptive message when possible:
-```json
+```jsonc
 {
     "error": "Invalid domain format",
     "message": "Domain must be a valid hostname without protocol or path"


### PR DESCRIPTION
When GitHub renders JSON markdown blocks with comments in it, it puts a red background behind the comments which hurts readability.

Example:

```json
{
    "key": "value" // Explanation
}
```

By changing the code blocks language to `jsonc` the comments are rendering in a better manner.


```jsonc
{
    "key": "value" // Explanation
}
```

I also aligned the comments in the Coupon structure code block so that they are all on the same column (I can split this out to be a separate PR if desired, but I figured it's a small enough fix to include with this PR).