### PR TITLE
feat: Add content.js logger util to prevent console pollution

### DIFF
--- a/Extension-React/public/background.js
+++ b/Extension-React/public/background.js
@@ -1,7 +1,8 @@
 chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
     if (request.action === "getCoupons") {
         fetch(
-            "https://api.discountdb.ch/api/v1/syrup/coupons?domain=" + request.domain,
+            "https://api.discountdb.ch/api/v1/syrup/coupons?domain=" +
+                request.domain
         )
             .then((response) => response.json())
             .then((data) => {
@@ -11,7 +12,9 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
                 sendResponse({ coupons: [] });
             });
         return true;
-    } else if (request.action === "setBadgeText") {
+    }
+
+    if (request.action === "setBadgeText") {
         chrome.action.setBadgeText({
             tabId: sender.tab.id,
             text: request.text,
@@ -20,5 +23,13 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
 
     if (request.action === "openPopup") {
         chrome.action.openPopup();
+    }
+
+    if (request.action === "checkDev") {
+        //https://developer.chrome.com/docs/extensions/reference/api/management#type-ExtensionInfo
+        chrome.management.getSelf((self) => {
+            sendResponse(self.installType === "development");
+        });
+        return true;
     }
 });

--- a/Extension-React/public/content.js
+++ b/Extension-React/public/content.js
@@ -60,7 +60,7 @@
                 return "woocommerce";
             }
         } catch (error) {
-            console.error("[Syrup] Error detecting platform:", error);
+            logger.warn("Failed to detect platform:", error);
         }
         return null;
     }
@@ -77,8 +77,8 @@
                     { action: "getCoupons", domain },
                     (response) => {
                         if (chrome.runtime.lastError) {
-                            console.error(
-                                "[Syrup] Runtime error during message passing:",
+                            logger.error(
+                                "Runtime error during message passing:",
                                 chrome.runtime.lastError
                             );
                             reject(chrome.runtime.lastError.message);
@@ -94,15 +94,13 @@
                             resolve();
                             chrome.storage.local.set({ coupons });
                         } else {
-                            console.warn(
-                                "[Syrup] No coupons returned from background."
-                            );
-                            reject("No coupons found");
+                            logger.warn("No coupons returned from background");
+                            resolve();
                         }
                     }
                 );
             } catch (error) {
-                console.error("[Syrup] Error fetching coupons:", error);
+                logger.error("Error fetching coupons:", error);
                 reject("Failed to fetch coupons");
             }
         });
@@ -119,7 +117,7 @@
             const translations = await response.json();
             return translations;
         } catch (error) {
-            console.error("Failed to load translations:", error);
+            logger.error("Failed to load translations:", error);
             return {};
         }
     }
@@ -129,7 +127,7 @@
             currentLang = lang;
             translations = await loadTranslations(lang);
         } catch (error) {
-            console.error("[Syrup] Error setting language:", error);
+            logger.error("Failed to set language:", error);
         }
     }
 
@@ -140,10 +138,7 @@
                 callback(storedLanguage || chrome.i18n.getUILanguage() || "en");
             });
         } catch (error) {
-            console.error(
-                "[Syrup] Error getting language from storage:",
-                error
-            );
+            logger.warn("Failed to get language from storage:", error);
             callback("en");
         }
     }
@@ -152,7 +147,7 @@
         try {
             return translations[key]?.message || key;
         } catch (error) {
-            console.error("[Syrup] Error getting message for key:", key, error);
+            logger.error("Error getting message for key:", key, error);
             return key;
         }
     }
@@ -168,11 +163,7 @@
             }
             return translated;
         } catch (error) {
-            console.error(
-                "[Syrup] Error getting translation for key:",
-                key,
-                error
-            );
+            logger.error("Error getting translation for key:", key, error);
             return key;
         }
     }
@@ -187,10 +178,7 @@
                 el.getClientRects().length
             );
         } catch (error) {
-            console.error(
-                "[Syrup] Error checking visibility of element:",
-                error
-            );
+            logger.warn("Failed to check visibility of element:", error);
             return false;
         }
     }
@@ -201,7 +189,7 @@
             const numericString = str.replace(/[^\d.-]/g, "");
             return parseFloat(numericString) || 0;
         } catch (error) {
-            console.error("[Syrup] Error parsing price:", error);
+            logger.warn("Error parsing price:", error);
             return 0;
         }
     }
@@ -218,8 +206,8 @@
             }
             return el;
         } catch (error) {
-            console.error(
-                `[Syrup] Error replacing value for selector: ${selector}`,
+            logger.warn(
+                `Failed to replace value for selector: ${selector}`,
                 error
             );
             return null;
@@ -239,9 +227,48 @@
             }
             await new Promise((resolve) => setTimeout(resolve, 1000));
         } catch (error) {
-            console.error("[Syrup] Error reverting coupon:", error);
+            logger.error("Error reverting coupon:", error);
         }
     }
+
+    const logger = {
+        get isDev() {
+            // Chrome extensions in dev mode don't have an update_url
+            return !chrome.runtime.getManifest().update_url;
+        },
+
+        prefix: "[Syrup]",
+        forceDebug: false,
+
+        log(...args) {
+            if (this.isDev || this.forceDebug) {
+                console.log(this.prefix, ...args);
+            }
+        },
+
+        info(...args) {
+            if (this.isDev || this.forceDebug) {
+                console.info(this.prefix, ...args);
+            }
+        },
+
+        warn(...args) {
+            if (this.isDev || this.forceDebug) {
+                console.warn(this.prefix, ...args);
+            }
+        },
+
+        error(...args) {
+            // Always log errors, even in production
+            console.error(this.prefix, ...args);
+        },
+
+        debug(...args) {
+            if (this.isDev || this.forceDebug) {
+                console.debug(this.prefix, ...args);
+            }
+        },
+    };
 
     /*******************************************************
      * 4. Testing & Applying Coupons
@@ -347,10 +374,7 @@
                 };
             }
         } catch (error) {
-            console.error(
-                `[Syrup] Error applying coupon ${couponCode}:`,
-                error
-            );
+            logger.error(`Error applying coupon ${couponCode}:`, error);
             return { success: false, priceDrop: 0, finalPrice: 0 };
         }
     }
@@ -405,10 +429,7 @@
                     config.removeCouponButtonSelector
                 );
             } catch (error) {
-                console.error(
-                    `[Syrup] Error testing coupon ${couponCode}:`,
-                    error
-                );
+                logger.error(`Error testing coupon ${couponCode}:`, error);
             }
         }
 
@@ -816,12 +837,12 @@
         try {
             await fetchCoupons(domain);
         } catch (err) {
-            console.error("[Syrup] Failed to fetch coupons:", err);
+            logger.warn("Failed to fetch coupons:", err);
             return;
         }
 
         if (!coupons || coupons.length === 0) {
-            console.log("[Syrup] No coupons found.");
+            logger.info("No coupons found");
             return; // No coupons to try
         }
 
@@ -856,7 +877,7 @@
 
     // Delay a bit for the page to load
     setTimeout(() => {
-        main().catch((err) => console.error("[Syrup] Main error:", err));
+        main().catch((err) => logger.error("Main error:", err));
     }, 3000);
 
     getLanguageFromStorage(setLanguage);


### PR DESCRIPTION
I noticed that the extension in production does quite a bit of logging to the page console, which can be distracting for developers and people looking for console messages from the page itself rather than any extensions. 

An example below:
<img width="400" alt="Screenshot 2025-01-08 121210" src="https://github.com/user-attachments/assets/57aa603c-0367-41bc-8a7d-7c57b79033b0" />

This suggested implementation creates a logger wrapper around the console, which will only log non-errors if the extension is detected as being loaded unpacked (ie. in a development environment). 

Note that one tradeoff of this implementation is that the trace of the console message will always direct you to the logger, and not the original caller. There may be a better way to do this, but I threw this together quite quickly. I'm open to suggestions. 