### PR TITLE
refactor: rename and update Syrup API client to V1

### DIFF
--- a/Extension-React/src/lib/sas/index.ts
+++ b/Extension-React/src/lib/sas/index.ts
@@ -1,1 +1,1 @@
-export { SyrupApiClient_v1_0_0 } from "@/lib/sas/v1-0-0";
+export { SyrupApiClientV1 } from "src/lib/sas/v1";

--- a/Extension-React/src/lib/sas/index.ts
+++ b/Extension-React/src/lib/sas/index.ts
@@ -1,1 +1,1 @@
-export { SyrupApiClientV1 } from "src/lib/sas/v1";
+export { SyrupApiClientV1 } from "@/lib/sas/v1";

--- a/Extension-React/src/lib/sas/v1/index.ts
+++ b/Extension-React/src/lib/sas/v1/index.ts
@@ -1,13 +1,16 @@
 import {
     ApiConfig,
-    CouponListResponse, ErrorResponse,
+    CouponListResponse,
+    ErrorResponse,
     ListCouponsParams,
     MerchantListResponse,
-    SuccessResponse, VersionResponse
+    SuccessResponse,
+    VersionResponse
 } from "@/lib/sas/models.ts";
 import { CacheManager, CacheOptions } from "@/lib/sas/cache.ts";
+import { SyrupAPIV1 } from "@/lib/sas/v1/interfaces.ts";
 
-export class SyrupApiClient_v1_0_0 {
+export class SyrupApiClientV1 implements SyrupAPIV1 {
     private readonly baseUrl: string;
     private readonly apiKey?: string;
     private readonly cacheManager: CacheManager;
@@ -85,7 +88,7 @@ export class SyrupApiClient_v1_0_0 {
     /**
      * Get Client Version information
      */
-    getClientVersion(): string {
+    async getClientVersion(): Promise<string> {
         return "1.0.0";
     }
 

--- a/Extension-React/src/lib/sas/v1/interfaces.ts
+++ b/Extension-React/src/lib/sas/v1/interfaces.ts
@@ -1,0 +1,22 @@
+import {
+    CouponListResponse,
+    ListCouponsParams,
+    MerchantListResponse,
+    SuccessResponse,
+    VersionResponse
+} from "@/lib/sas/models.ts";
+import { CacheOptions } from "@/lib/sas/cache.ts";
+
+export interface SyrupAPIV1 {
+    getVersion(): Promise<VersionResponse>;
+
+    getClientVersion(): Promise<string>;
+
+    listCoupons(params: ListCouponsParams & CacheOptions): Promise<CouponListResponse>;
+
+    reportValidCoupon(couponId: string): Promise<SuccessResponse>;
+
+    reportInvalidCoupon(couponId: string): Promise<SuccessResponse>;
+
+    listMerchants(options?: CacheOptions): Promise<MerchantListResponse>;
+}

--- a/Extension-React/src/lib/utils.ts
+++ b/Extension-React/src/lib/utils.ts
@@ -1,9 +1,9 @@
 import { clsx, type ClassValue } from "clsx";
 import { twMerge } from "tailwind-merge";
-import { SyrupApiClient_v1_0_0 } from "@/lib/sas";
+import { SyrupApiClientV1 } from "@/lib/sas";
 import { Coupon } from "@/lib/sas/models.ts";
 
-export const syrupApiClient = new SyrupApiClient_v1_0_0("https://api.discountdb.ch/api/v1/syrup");
+export const syrupApiClient = new SyrupApiClientV1("https://api.discountdb.ch/api/v1/syrup");
 
 export function cn(...inputs: ClassValue[]) {
     return twMerge(clsx(inputs));


### PR DESCRIPTION
Renamed SyrupApiClient_v1_0_0 to SyrupApiClientV1 for consistency. Added SyrupAPIV1 interface to improve type safety and modularity. Updated imports and file structure to align with the new naming convention.

@ImGajeed76 Please review <3